### PR TITLE
fix the distrubution build, adding ids to assembly.xmls

### DIFF
--- a/dist/src/main/assembly/assembly.xml
+++ b/dist/src/main/assembly/assembly.xml
@@ -21,6 +21,8 @@
    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
    xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0 http://maven.apache.org/xsd/assembly-1.1.0.xsd">
 
+   <id>distribution</id>
+
    <formats>
       <format>zip</format>
    </formats>

--- a/examples/swing_memory_grapher/src/main/assembly/assembly.xml
+++ b/examples/swing_memory_grapher/src/main/assembly/assembly.xml
@@ -20,6 +20,7 @@
    xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0"
    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
    xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0 http://maven.apache.org/xsd/assembly-1.1.0.xsd">
+   <id>cron_example_swing_memory_grapher_distribution</id>
    <formats>
       <format>zip</format>
    </formats>


### PR DESCRIPTION
New version of the assembly plugin requires id element in the assembly.xml

 Failed to execute goal org.apache.maven.plugins:maven-assembly-plugin:2.2.1:single (distribution) on project seam-cron-example-swing-graph: Assembly is incorrectly configured: null: Assembly is incorrectly configured: null:
Assembly: null is not configured correctly: Assembly ID must be present and non-empty.
