### PR TITLE
SEAMCRON-9: Store exception thrown during executeInvocationContext so…

### DIFF
--- a/providers/asynchronous/quartz/src/main/java/org/jboss/seam/cron/asynchronous/quartz/AsyncMethodInvocationJob.java
+++ b/providers/asynchronous/quartz/src/main/java/org/jboss/seam/cron/asynchronous/quartz/AsyncMethodInvocationJob.java
@@ -16,7 +16,7 @@
  */
 package org.jboss.seam.cron.asynchronous.quartz;
 
-import org.jboss.seam.cron.spi.asynchronous.support.FutureInvokerSupport;
+import org.jboss.seam.cron.spi.asynchronous.support.CallableInvoker;
 import org.quartz.Job;
 import org.quartz.JobExecutionContext;
 import org.quartz.JobExecutionException;
@@ -29,7 +29,7 @@ public class AsyncMethodInvocationJob implements Job {
 
     public void execute(final JobExecutionContext context) throws JobExecutionException {
         try {
-            final FutureInvokerSupport resultCallable = (FutureInvokerSupport) context.getJobDetail().getJobDataMap().get(QuartzAsynchronousProvider.DELAYED_RESULT_SUPPORT);
+            CallableInvoker resultCallable = (CallableInvoker) context.getJobDetail().getJobDataMap().get(QuartzAsynchronousProvider.DELAYED_RESULT_SUPPORT);
             resultCallable.executeInvocationContext();
         } catch (Exception ex) {
             throw new JobExecutionException("Error invoking method inside a Quartz Job", ex);

--- a/providers/asynchronous/quartz/src/main/java/org/jboss/seam/cron/asynchronous/quartz/QuartzAsynchronousProvider.java
+++ b/providers/asynchronous/quartz/src/main/java/org/jboss/seam/cron/asynchronous/quartz/QuartzAsynchronousProvider.java
@@ -29,7 +29,7 @@ import org.jboss.seam.cron.impl.scheduling.exception.CronProviderInitialisationE
 import org.jboss.seam.cron.spi.CronProviderLifecycle;
 import org.jboss.seam.cron.spi.asynchronous.CronAsynchronousProvider;
 import org.jboss.seam.cron.spi.asynchronous.Invoker;
-import org.jboss.seam.cron.spi.asynchronous.support.FutureInvokerSupport;
+import org.jboss.seam.cron.spi.asynchronous.support.CallableInvoker;
 import org.quartz.JobDetail;
 import org.quartz.Scheduler;
 import org.quartz.SchedulerException;
@@ -105,8 +105,8 @@ public class QuartzAsynchronousProvider implements CronProviderLifecycle, CronAs
         return asyncResult;
     }
 
-    private FutureInvokerSupport executeMethodAsScheduledJob(final Invoker invoker) throws AsynchronousMethodInvocationException {
-        final FutureInvokerSupport drs = new FutureInvokerSupport(invoker);
+    private CallableInvoker executeMethodAsScheduledJob(final Invoker invoker) throws AsynchronousMethodInvocationException {
+        final CallableInvoker drs = new CallableInvoker(invoker);
         try {
             final String name = UUID.randomUUID().toString();
             JobDetail jobDetail = new JobDetail(name, ASYNC_JOB_GROUP, AsyncMethodInvocationJob.class);

--- a/providers/asynchronous/queuj/src/main/java/org/jboss/seam/cron/asynchronous/queuj/AsyncMethodInvocationJob.java
+++ b/providers/asynchronous/queuj/src/main/java/org/jboss/seam/cron/asynchronous/queuj/AsyncMethodInvocationJob.java
@@ -18,7 +18,7 @@ package org.jboss.seam.cron.asynchronous.queuj;
 
 import com.workplacesystems.queuj.process.java.JavaProcessRunner;
 import org.jboss.seam.cron.impl.asynchronous.exception.AsynchronousMethodInvocationException;
-import org.jboss.seam.cron.spi.asynchronous.support.FutureInvokerSupport;
+import org.jboss.seam.cron.spi.asynchronous.support.CallableInvoker;
 
 /**
  *
@@ -26,7 +26,7 @@ import org.jboss.seam.cron.spi.asynchronous.support.FutureInvokerSupport;
  */
 public class AsyncMethodInvocationJob extends JavaProcessRunner {
 
-    public void execute(final FutureInvokerSupport resultCallable) {
+    public void execute(final CallableInvoker resultCallable) {
         try {
             resultCallable.executeInvocationContext();
         } catch (Exception ex) {

--- a/providers/asynchronous/queuj/src/main/java/org/jboss/seam/cron/asynchronous/queuj/QueuJAsynchronousProvider.java
+++ b/providers/asynchronous/queuj/src/main/java/org/jboss/seam/cron/asynchronous/queuj/QueuJAsynchronousProvider.java
@@ -35,7 +35,7 @@ import org.jboss.seam.cron.spi.CronProviderLifecycle;
 import org.jboss.seam.cron.spi.SeamCronExtension;
 import org.jboss.seam.cron.spi.asynchronous.CronAsynchronousProvider;
 import org.jboss.seam.cron.spi.asynchronous.Invoker;
-import org.jboss.seam.cron.spi.asynchronous.support.FutureInvokerSupport;
+import org.jboss.seam.cron.spi.asynchronous.support.CallableInvoker;
 import org.jboss.seam.cron.spi.queue.CronQueueProvider;
 import org.slf4j.Logger;
 
@@ -82,7 +82,7 @@ public class QueuJAsynchronousProvider implements CronProviderLifecycle, CronAsy
         return asyncResult;
     }
 
-    private FutureInvokerSupport executeMethodAsScheduledJob(final String queueId, final Invoker invoker) throws AsynchronousMethodInvocationException {
+    private CallableInvoker executeMethodAsScheduledJob(final String queueId, final Invoker invoker) throws AsynchronousMethodInvocationException {
         Queue<JavaProcessBuilder> queue = QueueFactory.DEFAULT_QUEUE;
         if (queueId != null) {
             CronQueueProvider queueProvider = cronExtension.getQueueProvider();
@@ -91,8 +91,8 @@ public class QueuJAsynchronousProvider implements CronProviderLifecycle, CronAsy
         JavaProcessBuilder jpb = queue.newProcessBuilder(Locale.getDefault());
         final String jobName = UUID.randomUUID().toString();
         jpb.setProcessName(jobName);
-        final FutureInvokerSupport drs = new FutureInvokerSupport(invoker);
-        jpb.setProcessDetails(new AsyncMethodInvocationJob(), "execute", new Class[] { FutureInvokerSupport.class }, new Object[] { drs });
+        final CallableInvoker drs = new CallableInvoker(invoker);
+        jpb.setProcessDetails(new AsyncMethodInvocationJob(), "execute", new Class[] { CallableInvoker.class }, new Object[] { drs });
         jpb.setProcessPersistence(false);
         jpb.newProcess();
         return drs;

--- a/providers/asynchronous/threads/src/main/java/org/jboss/seam/cron/asynchronous/threads/CallableFutureInvoker.java
+++ b/providers/asynchronous/threads/src/main/java/org/jboss/seam/cron/asynchronous/threads/CallableFutureInvoker.java
@@ -17,7 +17,7 @@
 package org.jboss.seam.cron.asynchronous.threads;
 
 import java.util.concurrent.Callable;
-import org.jboss.seam.cron.spi.asynchronous.support.FutureInvokerSupport;
+import org.jboss.seam.cron.spi.asynchronous.support.CallableInvoker;
 
 /**
  *
@@ -25,9 +25,9 @@ import org.jboss.seam.cron.spi.asynchronous.support.FutureInvokerSupport;
  */
 public class CallableFutureInvoker implements Callable {
 
-    private FutureInvokerSupport invoker;
+    private CallableInvoker invoker;
 
-    public CallableFutureInvoker(final FutureInvokerSupport invokerSupport) {
+    public CallableFutureInvoker(final CallableInvoker invokerSupport) {
         this.invoker = invokerSupport;
     }
 

--- a/providers/asynchronous/threads/src/main/java/org/jboss/seam/cron/asynchronous/threads/FutureInvoker.java
+++ b/providers/asynchronous/threads/src/main/java/org/jboss/seam/cron/asynchronous/threads/FutureInvoker.java
@@ -21,7 +21,7 @@ import java.util.concurrent.FutureTask;
 import java.util.concurrent.RunnableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import org.jboss.seam.cron.spi.asynchronous.support.FutureInvokerSupport;
+import org.jboss.seam.cron.spi.asynchronous.support.CallableInvoker;
 import org.jboss.seam.cron.spi.asynchronous.Invoker;
 
 /**
@@ -34,7 +34,7 @@ public class FutureInvoker implements RunnableFuture {
     private final RunnableFuture delegate;
 
     public FutureInvoker(final Invoker invoker) {
-        delegate = new FutureTask(new CallableFutureInvoker(new FutureInvokerSupport(invoker)));
+        delegate = new FutureTask(new CallableFutureInvoker(new CallableInvoker(invoker)));
     }
 
     public boolean isDone() {

--- a/spi/src/main/java/org/jboss/seam/cron/spi/asynchronous/AsynchronousInterceptor.java
+++ b/spi/src/main/java/org/jboss/seam/cron/spi/asynchronous/AsynchronousInterceptor.java
@@ -86,7 +86,7 @@ public class AsynchronousInterceptor {
 
                 if (Future.class.isAssignableFrom(ctx.getMethod().getReturnType())) {
                     // swap the "dummy" Future for a truly asynchronous future to return to the caller immediately
-                    ice.setPopResultsFromFuture(true);
+                    ice.setMethodReturnsFuture(true);
                     result = asyncStrategy.executeAndReturnFuture(queueId, ice);
                 } else {
                     asyncStrategy.executeWithoutReturn(queueId, ice);

--- a/spi/src/main/java/org/jboss/seam/cron/spi/asynchronous/CronAsynchronousProvider.java
+++ b/spi/src/main/java/org/jboss/seam/cron/spi/asynchronous/CronAsynchronousProvider.java
@@ -21,7 +21,7 @@ import java.util.concurrent.Future;
 /**
  * Interface to be implemented by providers of asynchronous method invocation.
  * The provider must call the #{@literal executeInvocationContext()} method on 
- * it to cause the original method to be executed. This will also cause the
+ * the #{@link Invoker} to cause the original method to be executed. This will also cause the
  * appropriate callback event to be fired on completion of the method invocation
  * so that the developer can respond to the result.
  * 

--- a/tck/src/test/java/org/jboss/seam/cron/test/asynchronous/tck/SeamCronAsynchronousTCKTest.java
+++ b/tck/src/test/java/org/jboss/seam/cron/test/asynchronous/tck/SeamCronAsynchronousTCKTest.java
@@ -133,7 +133,7 @@ public class SeamCronAsynchronousTCKTest {
     }
     
     @Test
-    public void testErrorThrownReturnsAsPerEJBSpec() {
+    public void testErrorThrownReturnsAsPerEJBSpec() throws Exception {
         log.info("Testing that an error thrown during an @Asynchronous invocation which returns a Future will be delivered to the caller as per the EJB spec");
         assertNotNull(asynchBean);
         asynchBean.reset();
@@ -142,12 +142,14 @@ public class SeamCronAsynchronousTCKTest {
             result.get(2, TimeUnit.SECONDS);
             fail("If you got here, the asynch method didn't throw an exception properly");
         } catch (ExecutionException ee) {
-            log.info("The correct kind of exception was found");
+            log.info("Checking that the correct kind of exception was found");
             assertEquals(NullPointerException.class, ee.getCause().getClass());
         } catch (TimeoutException toe) {
             log.error("Should not have timed out here!", toe);
+            throw toe;
         } catch (InterruptedException ie) {
             log.error("Should not have been interrupted here!", ie);
+            throw ie;
         }
         
     }


### PR DESCRIPTION
… we can rethrow it during the Callable.call() method that the real Future implementation will be calling (via CallableInvoker).  Added rethrowing of timeouts during the async test to catch failure to throw an exception during get(). Renamed FutureInvokerSupport to CallableInvoker.